### PR TITLE
Add c++11 option to fix compilation with g++

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,4 +20,5 @@ add_executable(Citip
     ${CMAKE_CURRENT_BINARY_DIR}/parser.cxx
     ${CMAKE_CURRENT_BINARY_DIR}/scanner.cxx
 )
+target_compile_options(Citip PUBLIC -std=c++11)
 target_link_libraries(Citip glpk)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,5 +20,5 @@ add_executable(Citip
     ${CMAKE_CURRENT_BINARY_DIR}/parser.cxx
     ${CMAKE_CURRENT_BINARY_DIR}/scanner.cxx
 )
-target_compile_options(Citip PUBLIC -std=c++11)
+set_property(TARGET Citip PROPERTY CXX_STANDARD 11)
 target_link_libraries(Citip glpk)


### PR DESCRIPTION
Just fixing a CMake-ism to make it explicitly compile with the -std=c++11 option.

(Thanks for this awesome code, btw! I'm planning to use it as a base for some parsing work of my own. I was lost on how to make a reentrant C++ scanner/parser with flex/bison until I found the post on your site.)